### PR TITLE
Fix icon offset for each position

### DIFF
--- a/Modules/Icons.lua
+++ b/Modules/Icons.lua
@@ -10,11 +10,24 @@ function Module:OnInitialize()
 
 end
 
+local offset_x_directions = {
+    ["TOPLEFT"] = 1,
+    ["TOPRIGHT"] = -1,
+    ["BOTTOMLEFT"] = 1,
+    ["BOTTOMRIGHT"] = -1,
+}
+local offset_y_directions = {
+    ["TOPLEFT"] = -1,
+    ["TOPRIGHT"] = -1,
+    ["BOTTOMLEFT"] = 1,
+    ["BOTTOMRIGHT"] = 1,
+}
+
 local function CreateCorruptionIcon(button, icon)
     local position = Config:GetOption("iconposition")
     local iconsize = 12
-    local offset_x = 2
-    local offset_y = 2
+    local offset_x = 2 * offset_x_directions[position]
+    local offset_y = 2 * offset_y_directions[position]
     if not button.corruption then
         button.corruption = CreateFrame("Frame", "$parent.corruption", button);
         button.corruption:SetPoint(position, button, position)


### PR DESCRIPTION
Correct offset directions for TOPLEFT, TOPRIGHT and BOTTOMRIGHT anchors

Looked like this before the fix:
![out_of_icon_offset](https://user-images.githubusercontent.com/1267001/80661926-b6843080-8a98-11ea-8732-9d3f5869e779.png)
