### PR TITLE
Fix inspect frame icons for party members

### DIFF
--- a/Modules/Icons.lua
+++ b/Modules/Icons.lua
@@ -146,7 +146,7 @@ function Module:OnLoad(event, ...)
         self:UnregisterEvent(event)
         if Config:GetOption("itemicon") ~= false then
             self:SecureHook("InspectPaperDollItemSlotButton_Update", function(button)
-                SetPaperDollCorruption(button, "target")
+                SetPaperDollCorruption(button, InspectFrame.unit)
             end)
         end
     end


### PR DESCRIPTION
Fixes #24 

Simple fix of unit id
Now can inspect party members without targeting them (with UnitId like party1, party2, etc.)
Also not showing own corruptions in inspect window, when targeting yourself